### PR TITLE
Move FFI logic into relevant submodules

### DIFF
--- a/lib/sodium.rb
+++ b/lib/sodium.rb
@@ -15,4 +15,4 @@ require 'sodium/hash'
 require 'sodium/one_time_auth'
 require 'sodium/secret_box'
 
-require 'sodium/na_cl'
+require 'sodium/ffi'

--- a/lib/sodium/buffer.rb
+++ b/lib/sodium/buffer.rb
@@ -74,11 +74,11 @@ class Sodium::Buffer
   end
 
   def self._mwipe!(buffer)
-    Sodium::NaCl.sodium_memzero(buffer, buffer.bytesize)
+    Sodium::FFI::Crypto.sodium_memzero(buffer, buffer.bytesize)
   end
 
   def self._mlock!(buffer)
-    Sodium::NaCl.mlock(buffer, buffer.bytesize) or
+    Sodium::FFI::LibC.mlock(buffer, buffer.bytesize) or
       raise Sodium::MemoryError, 'could not mlock(2) secure buffer into memory'
   end
 end

--- a/lib/sodium/ffi.rb
+++ b/lib/sodium/ffi.rb
@@ -1,0 +1,8 @@
+require 'sodium'
+require 'ffi'
+
+module Sodium::FFI
+end
+
+require 'sodium/ffi/lib_c'
+require 'sodium/ffi/crypto'

--- a/lib/sodium/ffi/crypto.rb
+++ b/lib/sodium/ffi/crypto.rb
@@ -1,9 +1,8 @@
-require 'sodium'
-require 'ffi'
+require 'sodium/ffi'
 require 'yaml'
 
-module Sodium::NaCl
-  CONFIG_PATH = File.expand_path('../../../config/nacl_ffi.yml', __FILE__)
+module Sodium::FFI::Crypto
+  CONFIG_PATH = File.expand_path('../../../../config/nacl_ffi.yml', __FILE__)
   CONFIG      = YAML.load_file(CONFIG_PATH)
 
   def self._install_default(delegate, configuration)
@@ -88,16 +87,14 @@ module Sodium::NaCl
   end
 end
 
-module Sodium::NaCl
+module Sodium::FFI::Crypto
   extend FFI::Library
 
-  ffi_lib FFI::Library::LIBC
   ffi_lib 'sodium'
-
 
   attach_function 'sodium_init',    [],                  :void
   attach_function 'sodium_memzero', [:pointer, :size_t], :void
-  attach_function 'mlock',          [:pointer, :size_t], :int
+
   sodium_init
 
   CONFIG.each do |configuration|

--- a/lib/sodium/ffi/lib_c.rb
+++ b/lib/sodium/ffi/lib_c.rb
@@ -1,0 +1,9 @@
+require 'sodium/ffi'
+
+module Sodium::FFI::LibC
+  extend FFI::Library
+
+  ffi_lib FFI::Library::LIBC
+
+  attach_function 'mlock', [:pointer, :size_t], :int
+end


### PR DESCRIPTION
This is in preparation for adding support for libsodium's random-number 
functions. Rather than shove more into one FFI module, this paves the way for
having FFI logic grouped into focused modules.
