### PR TITLE
Remove unnecessary mutex checking

### DIFF
--- a/lib/sodium/box.rb
+++ b/lib/sodium/box.rb
@@ -7,15 +7,10 @@ class Sodium::Box
     public_key = Sodium::Buffer.empty self.implementation[:PUBLICKEYBYTES]
     secret_key = Sodium::Buffer.empty self.implementation[:SECRETKEYBYTES]
 
-    # according to the libsodium docs, crypto_box_keypair is not
-    # thread-safe due to its use of the randombytes API, so we ensure
-    # it uses the same mutex as our own uses
-    Sodium::Random.synchronize do
-      self.implementation.nacl_keypair(
-        public_key.to_str,
-        secret_key.to_str
-      ) or raise Sodium::CryptoError, 'failed to generate a keypair'
-    end
+    self.implementation.nacl_keypair(
+      public_key.to_str,
+      secret_key.to_str
+    ) or raise Sodium::CryptoError, 'failed to generate a keypair'
 
     return secret_key, public_key
   end

--- a/lib/sodium/random.rb
+++ b/lib/sodium/random.rb
@@ -1,26 +1,16 @@
 require 'sodium'
 
 module Sodium::Random
-  @mutex = Mutex.new
-
-  def self.synchronize(&block)
-    @mutex.synchronize(&block)
-  end
-
   def self.bytes(size)
     Sodium::Buffer.empty(size) do |buffer|
-      self.synchronize do
-        Sodium::FFI::Random.randombytes_buf(
-          buffer.to_str,
-          buffer.bytesize
-        )
-      end
+      Sodium::FFI::Random.randombytes_buf(
+        buffer.to_str,
+        buffer.bytesize
+      )
     end
   end
 
   def self.integer(max = 2 ** 32 - 1)
-    self.synchronize do
-      Sodium::FFI::Random.randombytes_uniform(max)
-    end
+    Sodium::FFI::Random.randombytes_uniform(max)
   end
 end


### PR DESCRIPTION
The randombytes API in libsodium is _only_ non-threadsafe if
`sodium_init` hasn't been called prior. Since we explicitly call it when the
library is loaded, this is not actually a concern.
