### PR TITLE
Strip the message itself from the signature

### DIFF
--- a/lib/sodium/buffer.rb
+++ b/lib/sodium/buffer.rb
@@ -39,6 +39,13 @@ class Sodium::Buffer
       self.class._finalizer(@bytes)
   end
 
+  def +(other)
+    Sodium::Buffer.new(
+      self.to_str +
+      Sodium::Buffer.new(other).to_str
+    )
+  end
+
   def pad(size)
     self.class.new(
       ("\0" * size) + @bytes

--- a/lib/sodium/buffer.rb
+++ b/lib/sodium/buffer.rb
@@ -53,11 +53,61 @@ class Sodium::Buffer
   end
 
   def unpad(size)
-    self.class.new(
-      @bytes.respond_to?(:byteslice) ?
-        @bytes.byteslice(size .. -1) :
-        @bytes.unpack("@#{size}a*").first # 1.8
+    self.byteslice(size .. -1)
+  end
+
+  def byteslice(*args)
+    return self.class.new(
+      @bytes.byteslice(*args).to_s
+    ) if (
+      # Ruby 1.8 doesn't have byteslice
+      @bytes.respond_to?(:byteslice) or
+
+      # JRuby reuses memory regions when calling byteslice, which
+      # results in them getting cleared when the new buffer initializes
+      defined?(RUBY_ENGINE) and RUBY_ENGINE == 'java'
     )
+
+    raise ArgumentError, 'wrong number of arguments (0 for 1..2)' if
+      args.length < 1 or args.length > 2
+
+    start, finish = case
+      when args[1]
+        # matches: byteslice(start, size)
+        start  = args[0].to_i
+        size   = args[1].to_i
+
+        # if size is less than 1, finish needs to be small enough that
+        # `finish - start + 1 <= 0` even after finish is wrapped
+        # around to account for negative indices
+        finish = size > 0  ?
+          start + size - 1 :
+          - self.bytesize.succ
+
+        [ start, finish ]
+      when args[0].kind_of?(Range)
+        # matches: byteslice(start .. finish)
+        # matches: byteslice(start ... finish)
+        range  = args[0]
+        start  = range.begin.to_i
+        finish = range.exclude_end? ? range.end.to_i - 1 : range.end.to_i
+
+        [ start, finish ]
+      else
+        # matches: byteslice(start)
+        [ args[0].to_i, args[0].to_i ]
+    end
+
+    # ensure negative values are wrapped around explicitly
+    start  += self.bytesize if start  < 0
+    finish += self.bytesize if finish < 0
+    size    = finish - start + 1
+
+    bytes = (start >= 0 and size >= 0)         ?
+      @bytes.unpack("@#{start}a#{size}").first :
+      ''
+
+    self.class.new(bytes)
   end
 
   def bytesize

--- a/lib/sodium/sign.rb
+++ b/lib/sodium/sign.rb
@@ -49,7 +49,7 @@ class Sodium::Sign
 
     # signatures actually encode the message itself at the end, so we
     # slice off only the signature bytes
-    Sodium::Buffer.new signature.to_str.byteslice(
+    signature.byteslice(
       0,
       slen.read_ulong_long - message.to_str.bytesize
     )

--- a/lib/sodium/sign.rb
+++ b/lib/sodium/sign.rb
@@ -15,9 +15,9 @@ class Sodium::Sign
     return secret_key, public_key
   end
 
-  def self.open(key, signature)
+  def self.verify(key, message, signature)
     key       = self._public_key(key)
-    signature = self._signature(signature)
+    signature = self._signature(message, signature)
     message   = Sodium::Buffer.empty(signature.bytesize)
     mlen      = FFI::MemoryPointer.new(:ulong_long, 1, true)
 
@@ -27,9 +27,7 @@ class Sodium::Sign
       signature.to_str,
       signature.to_str.bytesize,
       key.to_str
-    ) or raise Sodium::CryptoError, 'failed to open the signature'
-
-    Sodium::Buffer.new message.to_str.slice(0, mlen.read_ulong_long)
+    )
   end
 
   def initialize(key)
@@ -49,7 +47,12 @@ class Sodium::Sign
       @key.to_str
     ) or raise Sodium::CryptoError, 'failed to generate signature'
 
-    Sodium::Buffer.new signature.to_str.slice(0, slen.read_ulong_long)
+    # signatures actually encode the message itself at the end, so we
+    # slice off only the signature bytes
+    Sodium::Buffer.new signature.to_str.byteslice(
+      0,
+      slen.read_ulong_long - message.to_str.bytesize
+    )
   end
 
   private
@@ -66,7 +69,7 @@ class Sodium::Sign
     Sodium::Buffer.new m
   end
 
-  def self._signature(s)
-    Sodium::Buffer.new s
+  def self._signature(m, s)
+    Sodium::Buffer.new(s) + m
   end
 end

--- a/test/sodium/buffer_test.rb
+++ b/test/sodium/buffer_test.rb
@@ -68,6 +68,44 @@ describe Sodium::Buffer do
     subject.new("\0\0\0s").unpad(3).to_str.must_equal 's'
   end
 
+  it '#byteslice must accept an indivdual byte offset to return' do
+    subject.new('xyz').tap do |buffer|
+      buffer.byteslice(-4).to_str.must_equal ''
+      buffer.byteslice(-3).to_str.must_equal 'x'
+      buffer.byteslice(-2).to_str.must_equal 'y'
+      buffer.byteslice(-1).to_str.must_equal 'z'
+      buffer.byteslice( 0).to_str.must_equal 'x'
+      buffer.byteslice( 1).to_str.must_equal 'y'
+      buffer.byteslice( 2).to_str.must_equal 'z'
+      buffer.byteslice( 3).to_str.must_equal ''
+    end
+  end
+
+  it '#byteslice must accept ranges of bytes to return' do
+    subject.new('xyz').tap do |buffer|
+      buffer.byteslice( 0.. 0).to_str.must_equal 'x'
+      buffer.byteslice( 0.. 1).to_str.must_equal 'xy'
+      buffer.byteslice( 0.. 2).to_str.must_equal 'xyz'
+      buffer.byteslice( 0.. 3).to_str.must_equal 'xyz'
+      buffer.byteslice( 1..-1).to_str.must_equal 'yz'
+      buffer.byteslice( 2..-2).to_str.must_equal ''
+      buffer.byteslice(-3..-1).to_str.must_equal 'xyz'
+      buffer.byteslice(-4.. 1).to_str.must_equal ''
+    end
+  end
+
+  it '#byteslice must accept an offset and number of bytes to return' do
+    subject.new('xyz').tap do |buffer|
+      buffer.byteslice( 0,  0).to_str.must_equal ''
+      buffer.byteslice( 0,  1).to_str.must_equal 'x'
+      buffer.byteslice( 0,  3).to_str.must_equal 'xyz'
+      buffer.byteslice( 2,  4).to_str.must_equal 'z'
+      buffer.byteslice( 2,  1).to_str.must_equal 'z'
+      buffer.byteslice(-2,  1).to_str.must_equal 'y'
+      buffer.byteslice( 0, -1).to_str.must_equal ''
+    end
+  end
+
   it '#bytesize must return its length' do
     subject.new('testing').bytesize.must_equal 7
   end

--- a/test/sodium/sign/ed25519_test.rb
+++ b/test/sodium/sign/ed25519_test.rb
@@ -19,7 +19,7 @@ describe Sodium::Sign::Ed25519 do
   let_64(:plaintext)  { 'bWVzc2FnZQ==' }
   let_64(:signature)  do
     %{ gBIV6VdlmL9aicHsrWMYhqGiQg3t1QGWmuj5oUNI2DN6FeaKKIkjPZ/N7vTM
-       R7ebY7+C7teQJMSrxlqTnrcnC21lc3NhZ2U= }
+       R7ebY7+C7teQJMSrxlqTnrcnCw== }
   end
 
   it '::primitive must be correct' do
@@ -45,8 +45,8 @@ describe Sodium::Sign::Ed25519 do
       must_equal self.signature
   end
 
-  it 'must open message signatures' do
-    self.klass.open(self.public_key, self.signature).to_str.
-      must_equal self.plaintext
+  it 'must verify message signatures' do
+    self.klass.verify(self.public_key, self.plaintext, self.signature).
+      must_equal true
   end
 end

--- a/test/sodium/sign_test.rb
+++ b/test/sodium/sign_test.rb
@@ -42,13 +42,6 @@ describe Sodium::Sign do
       must_raise Sodium::LengthError
   end
 
-  it 'must raise when opening a signature with an invalid key' do
-    public_key = self.keypair.last
-
-    lambda { self.klass.open(public_key.to_str[0..-2], 'message') }.
-      must_raise Sodium::LengthError
-  end
-
   it 'must raise when failing to generate keypairs' do
     sodium_stub_failure(self.klass, :nacl_keypair) do
       lambda { self.keypair }.
@@ -59,13 +52,6 @@ describe Sodium::Sign do
   it 'must raise when failing to sign a message' do
     sodium_stub_failure(self.klass, :nacl) do
       lambda { self.subject.sign('message') }.
-        must_raise Sodium::CryptoError
-    end
-  end
-
-  it 'must raise when failing to open a signature' do
-    sodium_stub_failure(self.klass, :nacl_open) do
-      lambda { self.klass.open(self.keypair.last, 'message') }.
         must_raise Sodium::CryptoError
     end
   end


### PR DESCRIPTION
The crypto_sign function encodes the original message in its signature
parameter, and the crypto_sign_verify take this entire message. Rather than
encode these two pieces together, we make the API more like the
Crypto::Auth API.
