### PR TITLE
Add several useful methods onto Sodium::Buffer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,9 @@ build/
 coverage/
 
 Gemfile.lock
+
+Makefile
+*.o
+*.so
+*.bundle
+.*.time

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,14 @@ script: bundle exec rake test
 bundler_args: --without tools
 
 env:
-  - >
-    LIBSODIUM_MIRROR="https://github.com/jedisct1/libsodium/tarball/%s"
-    LIBSODIUM_VERSION="master"
-# - >
-#   LIBSODIUM_MIRROR="http://download.dnscrypt.org/libsodium/releases/libsodium-%s.tar.gz"
-#   LIBSODIUM_VERSION=0.4.1
-#   LIBSODIUM_DIGEST=65756c7832950401cc0e6ee0e99b165974244e749f40f33d465f56447bae8ce3
+  matrix:
+    - >
+      LIBSODIUM_MIRROR="https://github.com/jedisct1/libsodium/tarball/%s"
+      LIBSODIUM_VERSION="master"
+#   - >
+#     LIBSODIUM_MIRROR="http://download.dnscrypt.org/libsodium/releases/libsodium-%s.tar.gz"
+#     LIBSODIUM_VERSION=0.4.1
+#     LIBSODIUM_DIGEST=65756c7832950401cc0e6ee0e99b165974244e749f40f33d465f56447bae8ce3
 
 rvm:
   - 1.8.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
 ### (Unreleased)
 
-* Added ability to use Sodium::Auth with class methods
+- Additions
+  * Sodium::Auth can be used entirely with class methods
+  * Sodium::Buffer gains many new API methods
+
+- Removals
+  * Sodium::Buffer loses #pad, #unpad
+
+- Enhancements
+  * Sodium::Buffer performance improvements
+
+- Bug Fixes
+  * Using `pointer` type for FFI methods to avoid bugs related to
+    in/out buffers in JRuby

--- a/config/nacl_ffi.yml
+++ b/config/nacl_ffi.yml
@@ -5,8 +5,8 @@
     - KEYBYTES
   
   :functions: 
-    ~      : [ buffer_out, buffer_in, ulong_long, buffer_in, int ]
-    :verify: [ buffer_in , buffer_in, ulong_long, buffer_in, int ]
+    ~      : [ pointer, pointer, ulong_long, pointer, int ]
+    :verify: [ pointer, pointer, ulong_long, pointer, int ]
 
   :primitives:
     - :HMACSHA512256
@@ -24,12 +24,12 @@
     - MACBYTES
     
   :functions:
-    ~            : [ buffer_out, buffer_in, ulong_long, buffer_in, buffer_in, buffer_in, int ]
-    :open        : [ buffer_out, buffer_in, ulong_long, buffer_in, buffer_in, buffer_in, int ]
-    :keypair     : [ buffer_out, buffer_out, int ]
-    :beforenm    : [ buffer_out, buffer_in, buffer_in, int ]
-    :afternm     : [ buffer_out, buffer_in, ulong_long, buffer_in, buffer_in, int ]
-    :open_afternm: [ buffer_out, buffer_in, ulong_long, buffer_in, buffer_in, int ]
+    ~            : [ pointer, pointer, ulong_long, pointer, pointer, pointer, int ]
+    :open        : [ pointer, pointer, ulong_long, pointer, pointer, pointer, int ]
+    :keypair     : [ pointer, pointer, int ]
+    :beforenm    : [ pointer, pointer, pointer, int ]
+    :afternm     : [ pointer, pointer, ulong_long, pointer, pointer, int ]
+    :open_afternm: [ pointer, pointer, ulong_long, pointer, pointer, int ]
 
   :primitives:
     - :Curve25519XSalsa20Poly1305
@@ -40,7 +40,7 @@
     - BYTES
 
   :functions:
-    ~: [ buffer_out, buffer_in, ulong_long, int ]
+    ~: [ pointer, pointer, ulong_long, int ]
 
   :primitives:
     - :SHA512
@@ -53,8 +53,8 @@
     - KEYBYTES
 
   :functions:
-    ~      : [ buffer_out, buffer_in, ulong_long, buffer_in, int ]
-    :verify: [ buffer_in , buffer_in, ulong_long, buffer_in, int ]
+    ~      : [ pointer, pointer, ulong_long, pointer, int ]
+    :verify: [ pointer, pointer, ulong_long, pointer, int ]
 
   :primitives:
     - :Poly1305
@@ -68,8 +68,8 @@
     - BOXZEROBYTES
 
   :functions:
-    ~    : [ buffer_out, buffer_in, ulong_long, buffer_in, buffer_in, int ]
-    :open: [ buffer_out, buffer_in, ulong_long, buffer_in, buffer_in, int ]
+    ~    : [ pointer, pointer, ulong_long, pointer, pointer, int ]
+    :open: [ pointer, pointer, ulong_long, pointer, pointer, int ]
 
   :primitives:
     - :XSalsa20Poly1305
@@ -82,9 +82,9 @@
     - SECRETKEYBYTES
 
   :functions:
-    ~      : [ buffer_out, buffer_out, buffer_in, ulong_long, buffer_in, int ]
-    open   : [ buffer_out, buffer_out, buffer_in, ulong_long, buffer_in, int ]
-    keypair: [ buffer_out, buffer_out, int ]
+    ~      : [ pointer, pointer, pointer, ulong_long, pointer, int ]
+    open   : [ pointer, pointer, pointer, ulong_long, pointer, int ]
+    keypair: [ pointer, pointer, int ]
 
   :primitives:
     - :Ed25519

--- a/ext/sodium/memory/extconf.rb
+++ b/ext/sodium/memory/extconf.rb
@@ -1,0 +1,11 @@
+#
+# FIXME: workaround for JRuby 1.7.4, where C extensions are
+# disabled. This can be removed, apparently, when 1.7.5 is released.
+#
+if defined? ENV_JAVA
+  ENV_JAVA['jruby.cext.enabled'] = 'true'
+end
+
+require 'mkmf'
+
+create_makefile('sodium/ffi/memory')

--- a/ext/sodium/memory/memory.c
+++ b/ext/sodium/memory/memory.c
@@ -1,0 +1,16 @@
+#include <stddef.h>
+
+void
+sodium_memxor(unsigned char *out, unsigned char *buf1, unsigned char *buf2, size_t size) {
+	size_t i;
+	for(i = 0; i < size; i++)
+		out[i] = buf1[i] ^ buf2[i];
+}
+
+void
+sodium_memput(unsigned char *out, unsigned char *in, size_t offset, size_t size) {
+	size_t i;
+	for (i = 0; i < size; i++) {
+		out[offset + i] = in[i];
+	}
+}

--- a/lib/sodium/box.rb
+++ b/lib/sodium/box.rb
@@ -28,7 +28,7 @@ class Sodium::Box
         nonce.to_str,
         shared_key.to_str
       ) or raise Sodium::CryptoError, 'failed to close the box'
-    end.unpad self.implementation[:BOXZEROBYTES]
+    end.ldrop self.implementation[:BOXZEROBYTES]
   end
 
   def self.open_afternm(shared_key, ciphertext, nonce)
@@ -44,7 +44,7 @@ class Sodium::Box
         nonce.to_str,
         shared_key.to_str
       ) or raise Sodium::CryptoError, 'failed to open the box'
-    end.unpad self.implementation[:ZEROBYTES]
+    end.ldrop self.implementation[:ZEROBYTES]
   end
 
 
@@ -70,7 +70,7 @@ class Sodium::Box
         @public_key.to_str,
         @secret_key.to_str
       ) or raise Sodium::CryptoError, 'failed to close the box'
-    end.unpad self.implementation[:BOXZEROBYTES]
+    end.ldrop self.implementation[:BOXZEROBYTES]
   end
 
   def open(ciphertext, nonce)
@@ -86,7 +86,7 @@ class Sodium::Box
         @public_key.to_str,
         @secret_key.to_str
       ) or raise Sodium::CryptoError, 'failed to open the box'
-    end.unpad self.implementation[:ZEROBYTES]
+    end.ldrop self.implementation[:ZEROBYTES]
   end
 
   def beforenm
@@ -114,11 +114,11 @@ class Sodium::Box
   end
 
   def self._message(m)
-    Sodium::Buffer.new(m).pad self.implementation[:ZEROBYTES]
+    Sodium::Buffer.lpad m, self.implementation[:ZEROBYTES]
   end
 
   def self._ciphertext(c)
-    Sodium::Buffer.new(c).pad self.implementation[:BOXZEROBYTES]
+    Sodium::Buffer.lpad c, self.implementation[:BOXZEROBYTES]
   end
 
   def self._nonce(n)

--- a/lib/sodium/buffer.rb
+++ b/lib/sodium/buffer.rb
@@ -168,6 +168,14 @@ class Sodium::Buffer
     @bytes.bytesize
   end
 
+  def rdrop(size)
+    self[0, self.bytesize - size]
+  end
+
+  def ldrop(size)
+    self[size, self.bytesize - size]
+  end
+
   def inspect
     # this appears to be equivalent to the default Object#inspect,
     # albeit without instance variables
@@ -176,14 +184,6 @@ class Sodium::Buffer
 
   def to_str
     @bytes.to_str
-  end
-
-  def pad(size)
-    self.class.lpad(self, size)
-  end
-
-  def unpad(size)
-    self[size, self.bytesize - size]
   end
 
   private

--- a/lib/sodium/buffer.rb
+++ b/lib/sodium/buffer.rb
@@ -61,6 +61,8 @@ class Sodium::Buffer
 
     ObjectSpace.define_finalizer self,
       self.class._finalizer(@bytes)
+
+    self.freeze
   end
 
   def +(other)

--- a/lib/sodium/buffer.rb
+++ b/lib/sodium/buffer.rb
@@ -14,6 +14,30 @@ class Sodium::Buffer
     self.new("\0" * size).tap {|buffer| yield buffer if block_given? }
   end
 
+  def self.ljust(string, size)
+    size = (size > string.bytesize) ? size : string.bytesize
+
+    self.empty(size) do |buffer|
+      buffer[0, string.bytesize] = string
+    end
+  end
+
+  def self.rjust(string, size)
+    size = (size > string.bytesize) ? size : string.bytesize
+
+    self.empty(size) do |buffer|
+      buffer[size - string.bytesize, string.bytesize] = string
+    end
+  end
+
+  def self.lpad(string, size, &block)
+    self.rjust(string, string.bytesize + size, &block)
+  end
+
+  def self.rpad(string, size, &block)
+    self.ljust(string, string.bytesize + size, &block)
+  end
+
   def self.new(bytes, size = bytes.bytesize)
     raise Sodium::LengthError, "buffer must be exactly #{size} bytes long" unless
       bytes.bytesize == size
@@ -43,12 +67,6 @@ class Sodium::Buffer
     Sodium::Buffer.new(
       self.to_str +
       Sodium::Buffer.new(other).to_str
-    )
-  end
-
-  def pad(size)
-    self.class.new(
-      ("\0" * size) + @bytes
     )
   end
 
@@ -144,6 +162,10 @@ class Sodium::Buffer
 
   def to_str
     @bytes.to_str
+  end
+
+  def pad(size)
+    self.class.lpad(self, size)
   end
 
   private

--- a/lib/sodium/buffer.rb
+++ b/lib/sodium/buffer.rb
@@ -56,7 +56,27 @@ class Sodium::Buffer
     self.byteslice(size .. -1)
   end
 
-  def byteslice(*args)
+  def []=(offset, size, bytes)
+    raise ArgumentError, %{must only assign to existing bytes in the buffer} unless
+      self.bytesize >= offset + size
+
+    raise ArgumentError, %{must reassign only a fixed number of bytes} unless
+      size == bytes.bytesize
+
+    # ensure the original bytes get cleared
+    bytes = Sodium::Buffer.new(bytes)
+
+    Sodium::FFI::Memory.sodium_memput(
+      self.to_str,
+      bytes.to_str,
+      offset,
+      size
+    )
+
+    true
+  end
+
+  def [](*args)
     return self.class.new(
       @bytes.byteslice(*args).to_s
     ) if (
@@ -109,6 +129,8 @@ class Sodium::Buffer
 
     self.class.new(bytes)
   end
+
+  alias byteslice []
 
   def bytesize
     @bytes.bytesize

--- a/lib/sodium/buffer.rb
+++ b/lib/sodium/buffer.rb
@@ -70,6 +70,22 @@ class Sodium::Buffer
     )
   end
 
+  def ^(other)
+    raise ArgumentError, %{must only XOR strings of equal length} unless
+      self.bytesize == other.bytesize
+
+    Sodium::Buffer.empty(self.bytesize) do |buffer|
+      other = Sodium::Buffer.new
+
+      Sodium::FFI::Memory.sodium_memxor(
+        buffer.to_str,
+        self.to_str,
+        other.to_str,
+        other.bytesize
+      )
+    end
+  end
+
   def unpad(size)
     self.byteslice(size .. -1)
   end

--- a/lib/sodium/buffer.rb
+++ b/lib/sodium/buffer.rb
@@ -155,6 +155,9 @@ class Sodium::Buffer
     finish += self.bytesize if finish < 0
     size    = finish - start + 1
 
+    # this approach ensures the bytes are copied into new memory, so
+    # instantiating a new buffer doesn't clear the bytes in the
+    # existing buffer
     bytes = (start >= 0 and size >= 0)         ?
       @bytes.unpack("@#{start}a#{size}").first :
       ''

--- a/lib/sodium/buffer.rb
+++ b/lib/sodium/buffer.rb
@@ -65,25 +65,25 @@ class Sodium::Buffer
     self.freeze
   end
 
-  def +(other)
-    Sodium::Buffer.empty(self.bytesize + other.bytesize) do |buffer|
+  def +(bytes)
+    Sodium::Buffer.empty(self.bytesize + bytes.bytesize) do |buffer|
       buffer[0,             self .bytesize] = self
-      buffer[self.bytesize, other.bytesize] = other
+      buffer[self.bytesize, bytes.bytesize] = bytes
     end
   end
 
-  def ^(other)
+  def ^(bytes)
+    bytes = Sodium::Buffer.new(bytes)
+
     raise ArgumentError, %{must only XOR strings of equal length} unless
-      self.bytesize == other.bytesize
+      self.bytesize == bytes.bytesize
 
     Sodium::Buffer.empty(self.bytesize) do |buffer|
-      other = Sodium::Buffer.new
-
       Sodium::FFI::Memory.sodium_memxor(
         buffer.to_str,
         self.to_str,
-        other.to_str,
-        other.bytesize
+        bytes.to_str,
+        bytes.bytesize
       )
     end
   end

--- a/lib/sodium/buffer.rb
+++ b/lib/sodium/buffer.rb
@@ -65,6 +65,19 @@ class Sodium::Buffer
     self.freeze
   end
 
+  def ==(bytes)
+    bytes = Sodium::Buffer.new(bytes)
+
+    return false unless
+      self.bytesize == bytes.bytesize
+
+    Sodium::FFI::Crypto.sodium_memcmp(
+      self.to_str,
+      bytes.to_str,
+      bytes.bytesize
+    ) == 0
+  end
+
   def +(bytes)
     Sodium::Buffer.empty(self.bytesize + bytes.bytesize) do |buffer|
       buffer[0,             self .bytesize] = self

--- a/lib/sodium/buffer.rb
+++ b/lib/sodium/buffer.rb
@@ -64,10 +64,10 @@ class Sodium::Buffer
   end
 
   def +(other)
-    Sodium::Buffer.new(
-      self.to_str +
-      Sodium::Buffer.new(other).to_str
-    )
+    Sodium::Buffer.empty(self.bytesize + other.bytesize) do |buffer|
+      buffer[0,             self .bytesize] = self
+      buffer[self.bytesize, other.bytesize] = other
+    end
   end
 
   def ^(other)
@@ -84,10 +84,6 @@ class Sodium::Buffer
         other.bytesize
       )
     end
-  end
-
-  def unpad(size)
-    self.byteslice(size .. -1)
   end
 
   def []=(offset, size, bytes)
@@ -182,6 +178,10 @@ class Sodium::Buffer
 
   def pad(size)
     self.class.lpad(self, size)
+  end
+
+  def unpad(size)
+    self[size, self.bytesize - size]
   end
 
   private

--- a/lib/sodium/ffi.rb
+++ b/lib/sodium/ffi.rb
@@ -6,4 +6,5 @@ end
 
 require 'sodium/ffi/lib_c'
 require 'sodium/ffi/crypto'
+require 'sodium/ffi/memory'
 require 'sodium/ffi/random'

--- a/lib/sodium/ffi/crypto.rb
+++ b/lib/sodium/ffi/crypto.rb
@@ -92,8 +92,9 @@ module Sodium::FFI::Crypto
 
   ffi_lib 'sodium'
 
-  attach_function 'sodium_init',    [],                  :void
-  attach_function 'sodium_memzero', [:pointer, :size_t], :void
+  attach_function 'sodium_init',    [],                            :void
+  attach_function 'sodium_memzero', [:pointer, :size_t],           :void
+  attach_function 'sodium_memcmp',  [:pointer, :pointer, :size_t], :int
 
   sodium_init
 

--- a/lib/sodium/ffi/memory.rb
+++ b/lib/sodium/ffi/memory.rb
@@ -1,0 +1,12 @@
+require 'pathname'
+
+module Sodium::FFI::Memory
+  extend FFI::Library
+
+  ffi_lib Pathname.new(__FILE__).dirname.join(
+    %{memory.#{RbConfig::MAKEFILE_CONFIG['DLEXT']}}
+  )
+
+  attach_function 'sodium_memxor', [:pointer, :pointer, :pointer, :size_t ], :void
+  attach_function 'sodium_memput', [:pointer, :pointer, :size_t,  :size_t ], :void
+end

--- a/lib/sodium/secret_box.rb
+++ b/lib/sodium/secret_box.rb
@@ -27,7 +27,7 @@ class Sodium::SecretBox
         nonce.to_str,
         @key.to_str
       ) or raise Sodium::CryptoError, 'failed to close the secret box'
-    end.unpad self.implementation[:BOXZEROBYTES]
+    end.ldrop self.implementation[:BOXZEROBYTES]
   end
 
   def open(ciphertext, nonce)
@@ -42,7 +42,7 @@ class Sodium::SecretBox
         nonce.to_str,
         @key.to_str
       ) or raise Sodium::CryptoError, 'failed to open the secret box'
-    end.unpad self.implementation[:ZEROBYTES]
+    end.ldrop self.implementation[:ZEROBYTES]
   end
 
   private
@@ -52,11 +52,11 @@ class Sodium::SecretBox
   end
 
   def self._message(m)
-    Sodium::Buffer.new(m).pad self.implementation[:ZEROBYTES]
+    Sodium::Buffer.lpad m, self.implementation[:ZEROBYTES]
   end
 
   def self._ciphertext(c)
-    Sodium::Buffer.new(c).pad self.implementation[:BOXZEROBYTES]
+    Sodium::Buffer.lpad c, self.implementation[:BOXZEROBYTES]
   end
 
   def self._nonce(n)

--- a/sodium.gemspec
+++ b/sodium.gemspec
@@ -10,10 +10,10 @@ Gem::Specification.new do |gem|
   gem.description = 'A library for performing cryptography based on modern ciphers and protocols'
 
   gem.bindir      = 'bin'
-  gem.files       = `git ls-files`            .split("\n")
-  gem.extensions  = `git ls-files -- ext/*.rb`.split("\n")
-  gem.executables = `git ls-files -- bin/*`   .split("\n").map {|e| File.basename(e) }
-  gem.test_files  = `git ls-files -- spec/*`  .split("\n")
+  gem.files       = `git ls-files`               .split("\n")
+  gem.executables = `git ls-files -- bin/*`      .split("\n").map {|e| File.basename(e) }
+  gem.extensions  = `git ls-files -- ext/**/*.rb`.split("\n")
+  gem.test_files  = `git ls-files -- spec/*`     .split("\n")
 
   gem.requirements << 'libsodium ~> 0.5'
 

--- a/tasks/extensions.rake
+++ b/tasks/extensions.rake
@@ -1,0 +1,24 @@
+namespace :compile do
+  LIB_PATH   = File.expand_path('../../lib',        __FILE__)
+  EXT_PATH   = File.expand_path('../../ext/sodium', __FILE__)
+
+  MEMORY_PATH = File.join EXT_PATH,    'memory'
+  MEMORY_SRC  = File.join MEMORY_PATH, '*.c'
+  MEMORY_LIB  = 'memory.' + RbConfig::CONFIG['DLEXT']
+
+  desc 'Compile the memory extension'
+  task :memory => %{#{LIB_PATH}/sodium/ffi/#{MEMORY_LIB}}
+
+  file %{#{LIB_PATH}/sodium/ffi/#{MEMORY_LIB}} => %{#{MEMORY_PATH}/Makefile} do
+    sh %{make -C #{MEMORY_PATH} install sitearchdir="#{LIB_PATH}"}
+  end
+
+  file %{#{MEMORY_PATH}/Makefile} => FileList[MEMORY_SRC] do
+    Dir.chdir(MEMORY_PATH) { ruby %{extconf.rb} }
+  end
+end
+
+desc 'Compile all native extensions'
+task :compile => %w{ compile:memory }
+
+task :test => %w{ compile }

--- a/test/sodium/buffer_test.rb
+++ b/test/sodium/buffer_test.rb
@@ -37,6 +37,32 @@ describe Sodium::Buffer do
     mock.verify
   end
 
+  it '::ljust must pad zero bytes on the end' do
+    subject.ljust('xyz', 5).to_str.must_equal "xyz\0\0"
+  end
+
+  it '::ljust must not pad bytes when not needed' do
+    subject.ljust('xyz', 2).to_str.must_equal 'xyz'
+  end
+
+  it '::rjust must pad zero bytes onto the front' do
+    subject.rjust('xyz', 5).to_str.must_equal "\0\0xyz"
+  end
+
+  it '::rjust must not pad bytes when not needed' do
+    subject.rjust('xyz', 2).to_str.must_equal 'xyz'
+  end
+
+  it '::lpad must prepend the required number of bytes' do
+    subject.lpad('xyz', 0).to_str.must_equal 'xyz'
+    subject.lpad('xyz', 2).to_str.must_equal "\0\0xyz"
+  end
+
+  it '::rpad must append the required number of bytes' do
+    subject.rpad('xyz', 0).to_str.must_equal 'xyz'
+    subject.rpad('xyz', 2).to_str.must_equal "xyz\0\0"
+  end
+
   it '::new must create a buffer containing the specified string' do
     subject.new('xyz'     ).to_str.must_equal('xyz')
     subject.new('xyz' * 50).to_str.must_equal('xyz' * 50)

--- a/test/sodium/buffer_test.rb
+++ b/test/sodium/buffer_test.rb
@@ -86,6 +86,15 @@ describe Sodium::Buffer do
   it '#initialize must wipe the buffer during finalization'
   it '#initialize must prevent the string from being paged to disk'
 
+  it '#== must compare equality of two buffers' do
+    subject.new('xyz').==('xyz') .must_equal true
+    subject.new('xyz').==('xy')  .must_equal false
+    subject.new('xyz').==('xyzz').must_equal false
+    subject.new('xyz').==('abc') .must_equal false
+  end
+
+  it '#== must compare equality of two buffers in constant time'
+
   it '#+ must append two buffers' do
     subject.new('xyz').+('abc').to_str.must_equal 'xyzabc'
   end

--- a/test/sodium/buffer_test.rb
+++ b/test/sodium/buffer_test.rb
@@ -86,14 +86,6 @@ describe Sodium::Buffer do
   it '#initialize must wipe the buffer during finalization'
   it '#initialize must prevent the string from being paged to disk'
 
-  it '#pad bytes onto the front' do
-    subject.new('s').pad(3).to_str.must_equal "\0\0\0s"
-  end
-
-  it '#unpad bytes from the front' do
-    subject.new("\0\0\0s").unpad(3).to_str.must_equal 's'
-  end
-
   it '#[]= must allow replacement of byte ranges' do
     subject.new('xyz').tap {|b| b[0, 3] = 'abc' }.to_str.must_equal 'abc'
     subject.new('xyz').tap {|b| b[0, 2] = 'ab'  }.to_str.must_equal 'abz'
@@ -147,6 +139,14 @@ describe Sodium::Buffer do
 
   it '#[] must return its length' do
     subject.new('testing').bytesize.must_equal 7
+  end
+
+  it '#ldrop must drop bytes off the left' do
+    subject.new('xyz').ldrop(2).to_str.must_equal('z')
+  end
+
+  it '#rdrop must drop bytes off the right' do
+    subject.new('xyz').rdrop(2).to_str.must_equal('x')
   end
 
   it '#inspect must not reveal its instance variables' do

--- a/test/sodium/buffer_test.rb
+++ b/test/sodium/buffer_test.rb
@@ -94,45 +94,58 @@ describe Sodium::Buffer do
     subject.new("\0\0\0s").unpad(3).to_str.must_equal 's'
   end
 
-  it '#byteslice must accept an indivdual byte offset to return' do
+  it '#[]= must allow replacement of byte ranges' do
+    subject.new('xyz').tap {|b| b[0, 3] = 'abc' }.to_str.must_equal 'abc'
+    subject.new('xyz').tap {|b| b[0, 2] = 'ab'  }.to_str.must_equal 'abz'
+    subject.new('xyz').tap {|b| b[2, 1] = 'c'   }.to_str.must_equal 'xyc'
+  end
+
+  it '#[]= must not allow resizing the buffer' do
+    lambda { subject.new('xyz')[0, 1] = 'ab' }.must_raise ArgumentError
+    lambda { subject.new('xyz')[0, 2] = 'a'  }.must_raise ArgumentError
+    lambda { subject.new('xyz')[3, 1] = 'a'  }.must_raise ArgumentError
+    lambda { subject.new('xyz')[2, 2] = 'ab' }.must_raise ArgumentError
+  end
+
+  it '#[] must accept an indivdual byte offset to return' do
     subject.new('xyz').tap do |buffer|
-      buffer.byteslice(-4).to_str.must_equal ''
-      buffer.byteslice(-3).to_str.must_equal 'x'
-      buffer.byteslice(-2).to_str.must_equal 'y'
-      buffer.byteslice(-1).to_str.must_equal 'z'
-      buffer.byteslice( 0).to_str.must_equal 'x'
-      buffer.byteslice( 1).to_str.must_equal 'y'
-      buffer.byteslice( 2).to_str.must_equal 'z'
-      buffer.byteslice( 3).to_str.must_equal ''
+      buffer[-4].to_str.must_equal ''
+      buffer[-3].to_str.must_equal 'x'
+      buffer[-2].to_str.must_equal 'y'
+      buffer[-1].to_str.must_equal 'z'
+      buffer[ 0].to_str.must_equal 'x'
+      buffer[ 1].to_str.must_equal 'y'
+      buffer[ 2].to_str.must_equal 'z'
+      buffer[ 3].to_str.must_equal ''
     end
   end
 
-  it '#byteslice must accept ranges of bytes to return' do
+  it '#[] must accept ranges of bytes to return' do
     subject.new('xyz').tap do |buffer|
-      buffer.byteslice( 0.. 0).to_str.must_equal 'x'
-      buffer.byteslice( 0.. 1).to_str.must_equal 'xy'
-      buffer.byteslice( 0.. 2).to_str.must_equal 'xyz'
-      buffer.byteslice( 0.. 3).to_str.must_equal 'xyz'
-      buffer.byteslice( 1..-1).to_str.must_equal 'yz'
-      buffer.byteslice( 2..-2).to_str.must_equal ''
-      buffer.byteslice(-3..-1).to_str.must_equal 'xyz'
-      buffer.byteslice(-4.. 1).to_str.must_equal ''
+      buffer[ 0.. 0].to_str.must_equal 'x'
+      buffer[ 0.. 1].to_str.must_equal 'xy'
+      buffer[ 0.. 2].to_str.must_equal 'xyz'
+      buffer[ 0.. 3].to_str.must_equal 'xyz'
+      buffer[ 1..-1].to_str.must_equal 'yz'
+      buffer[ 2..-2].to_str.must_equal ''
+      buffer[-3..-1].to_str.must_equal 'xyz'
+      buffer[-4.. 1].to_str.must_equal ''
     end
   end
 
-  it '#byteslice must accept an offset and number of bytes to return' do
+  it '#[] must accept an offset and number of bytes to return' do
     subject.new('xyz').tap do |buffer|
-      buffer.byteslice( 0,  0).to_str.must_equal ''
-      buffer.byteslice( 0,  1).to_str.must_equal 'x'
-      buffer.byteslice( 0,  3).to_str.must_equal 'xyz'
-      buffer.byteslice( 2,  4).to_str.must_equal 'z'
-      buffer.byteslice( 2,  1).to_str.must_equal 'z'
-      buffer.byteslice(-2,  1).to_str.must_equal 'y'
-      buffer.byteslice( 0, -1).to_str.must_equal ''
+      buffer[ 0,  0].to_str.must_equal ''
+      buffer[ 0,  1].to_str.must_equal 'x'
+      buffer[ 0,  3].to_str.must_equal 'xyz'
+      buffer[ 2,  4].to_str.must_equal 'z'
+      buffer[ 2,  1].to_str.must_equal 'z'
+      buffer[-2,  1].to_str.must_equal 'y'
+      buffer[ 0, -1].to_str.must_equal ''
     end
   end
 
-  it '#bytesize must return its length' do
+  it '#[] must return its length' do
     subject.new('testing').bytesize.must_equal 7
   end
 

--- a/test/sodium/buffer_test.rb
+++ b/test/sodium/buffer_test.rb
@@ -86,6 +86,15 @@ describe Sodium::Buffer do
   it '#initialize must wipe the buffer during finalization'
   it '#initialize must prevent the string from being paged to disk'
 
+  it '#+ must append two buffers' do
+    subject.new('xyz').+('abc').to_str.must_equal 'xyzabc'
+  end
+
+  it '#^ must XOR two buffers' do
+    subject.new('xyz').^('xyz').to_str.must_equal "\0\0\0"
+    subject.new('xyz').^('xyz').to_str.must_equal "\0\0\0"
+  end
+
   it '#[]= must allow replacement of byte ranges' do
     subject.new('xyz').tap {|b| b[0, 3] = 'abc' }.to_str.must_equal 'abc'
     subject.new('xyz').tap {|b| b[0, 2] = 'ab'  }.to_str.must_equal 'abz'


### PR DESCRIPTION
Includes fast implementations of #[], #[]= and faster replacements for
allows for XORing Ruby strings as well as replacing bytes in them.
