### PR TITLE
Allow Sodium::Auth to be called entirely with class methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+### (Unreleased)
+
+* Added ability to use Sodium::Auth with class methods

--- a/lib/sodium/auth.rb
+++ b/lib/sodium/auth.rb
@@ -7,33 +7,43 @@ class Sodium::Auth
     Sodium::Buffer.key self.implementation[:KEYBYTES]
   end
 
-  def initialize(key)
-    @key = self.class._key(key)
-  end
-
-  def auth(message)
-    message = self.class._message(message)
+  def self.auth(key, message)
+    key     = self._key(key)
+    message = self._message(message)
 
     Sodium::Buffer.empty self.implementation[:BYTES] do |authenticator|
       self.implementation.nacl(
         authenticator.to_str,
         message.to_str,
         message.to_str.bytesize,
-        @key.to_str
+        key.to_str
       ) or raise Sodium::CryptoError, 'failed to generate an authenticator'
     end
   end
 
-  def verify(message, authenticator)
-    message       = self.class._message(message)
-    authenticator = self.class._authenticator(authenticator)
+  def self.verify(key, message, authenticator)
+    key           = self._key(key)
+    message       = self._message(message)
+    authenticator = self._authenticator(authenticator)
 
     self.implementation.nacl_verify(
       authenticator.to_str,
       message.to_str,
       message.to_str.bytesize,
-      @key.to_str
+      key.to_str
     )
+  end
+
+  def initialize(key)
+    @key = self.class._key(key)
+  end
+
+  def auth(message)
+    self.class.auth(@key, message)
+  end
+
+  def verify(message, authenticator)
+    self.class.verify(@key, message, authenticator)
   end
 
   private

--- a/test/sodium/auth/hmacsha256_test.rb
+++ b/test/sodium/auth/hmacsha256_test.rb
@@ -33,12 +33,23 @@ describe Sodium::Auth::HMACSHA256 do
   end
 
   it 'must generate authenticators' do
+    self.klass.auth(
+      self.key,
+      self.plaintext
+    ).to_str.must_equal self.authenticator
+
     self.subject.auth(
       self.plaintext
     ).to_str.must_equal self.authenticator
   end
 
   it 'must verify authenticators' do
+    self.klass.verify(
+      self.key,
+      self.plaintext,
+      self.authenticator
+    ).must_equal true
+
     self.subject.verify(
       self.plaintext,
       self.authenticator

--- a/test/sodium/auth/hmacsha512256_test.rb
+++ b/test/sodium/auth/hmacsha512256_test.rb
@@ -32,12 +32,23 @@ describe Sodium::Auth::HMACSHA512256 do
   end
 
   it 'must generate authenticators' do
+    self.klass.auth(
+      self.key,
+      self.plaintext
+    ).to_str.must_equal self.authenticator
+
     self.subject.auth(
       self.plaintext
     ).to_str.must_equal self.authenticator
   end
 
   it 'must verify authenticators' do
+    self.klass.verify(
+      self.key,
+      self.plaintext,
+      self.authenticator
+    ).must_equal true
+
     self.subject.verify(
       self.plaintext,
       self.authenticator


### PR DESCRIPTION
This is useful for PBKDF2 support in the Cryptography project. Since PBKDF2
requires hundreds of thousands of iterations of the HMAC, the additional
overhead of allocating objects becomes significant.
