### PR TITLE
Only tr once we've set the encoding to BINARY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### unreleased
+
+- Bug Fixes
+  * Sodium::Buffer again accepts binary strings that aren't valid Unicode
+
 ### 0.6.1 (2013-06-27)
 
 - Additions

--- a/lib/sodium/buffer.rb
+++ b/lib/sodium/buffer.rb
@@ -51,10 +51,10 @@ class Sodium::Buffer
     # initialize with a forced hard copy of the bytes (Ruby is smart
     # about using copy-on-write for strings 24 bytes or longer, so we
     # have to perform a no-op that forces Ruby to copy the bytes)
-    @bytes = bytes.tr('','').tap {|s|
+    @bytes = bytes.dup.tap {|s|
       s.force_encoding('BINARY') if
       s.respond_to?(:force_encoding)
-    }.freeze
+    }.tr('', '').freeze
 
     self.class._mlock! @bytes
     self.class._mwipe!  bytes


### PR DESCRIPTION
String#tr fails if the input string contains invalid Unicode characters. This
is fine, but only if the string realizes that it's binary data rather than
Unicode encoded characters. So we force it to binary mode _before_ we
String#tr.

The String#dup doesn't actually duplicate the string's contents, or we'd worry
about making a copy of the potentially-sensitive data in memory. This isn't an
issue for the exact reason we're doing String#tr in the first place: Ruby is
smart enough to copy-on-write the memory used for the String.
