### PR TITLE
Rewrite Sodium::Buffer to use an FFI::Pointer rather than a String

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,18 @@
-### 0.6.1 (2013-07-09)
+### unreleased
+
+- Additions
+  * Sodium::Buffer#to_ptr added to replace #to_str
+  * Sodium::Buffer#to_s added to replace #to_str
+
+- Removals
+  * Sodium::Buffer#to_str removed
+
+- Bug Fixes
+  * Potential data loss bug fixed. Sodium::Buffer can no longer be
+    garbage collected (thus clearing its bytes) while a pointer to its
+    bytes (from #to_ptr) is being held.
+
+### 0.6.2 (2013-07-09)
 
 - Additions
   * now actually distributed with a license! (MIT)

--- a/lib/sodium/auth.rb
+++ b/lib/sodium/auth.rb
@@ -13,10 +13,10 @@ class Sodium::Auth
 
     Sodium::Buffer.empty self.implementation[:BYTES] do |authenticator|
       self.implementation.nacl(
-        authenticator.to_str,
-        message.to_str,
-        message.to_str.bytesize,
-        key.to_str
+        authenticator.to_ptr,
+        message      .to_ptr,
+        message      .bytesize,
+        key          .to_ptr
       ) or raise Sodium::CryptoError, 'failed to generate an authenticator'
     end
   end
@@ -27,10 +27,10 @@ class Sodium::Auth
     authenticator = self._authenticator(authenticator)
 
     self.implementation.nacl_verify(
-      authenticator.to_str,
-      message.to_str,
-      message.to_str.bytesize,
-      key.to_str
+      authenticator.to_ptr,
+      message      .to_ptr,
+      message      .bytesize,
+      key          .to_ptr
     )
   end
 

--- a/lib/sodium/box.rb
+++ b/lib/sodium/box.rb
@@ -8,8 +8,8 @@ class Sodium::Box
     secret_key = Sodium::Buffer.empty self.implementation[:SECRETKEYBYTES]
 
     self.implementation.nacl_keypair(
-      public_key.to_str,
-      secret_key.to_str
+      public_key.to_ptr,
+      secret_key.to_ptr
     ) or raise Sodium::CryptoError, 'failed to generate a keypair'
 
     return secret_key, public_key
@@ -22,11 +22,11 @@ class Sodium::Box
 
     Sodium::Buffer.empty(message.bytesize) do |ciphertext|
       self.implementation.nacl_afternm(
-        ciphertext.to_str,
-        message.to_str,
-        message.to_str.bytesize,
-        nonce.to_str,
-        shared_key.to_str
+        ciphertext.to_ptr,
+        message   .to_ptr,
+        message   .bytesize,
+        nonce     .to_ptr,
+        shared_key.to_ptr
       ) or raise Sodium::CryptoError, 'failed to close the box'
     end.ldrop self.implementation[:BOXZEROBYTES]
   end
@@ -38,11 +38,11 @@ class Sodium::Box
 
     Sodium::Buffer.empty(ciphertext.bytesize) do |message|
       self.implementation.nacl_open_afternm(
-        message.to_str,
-        ciphertext.to_str,
-        ciphertext.to_str.bytesize,
-        nonce.to_str,
-        shared_key.to_str
+        message   .to_ptr,
+        ciphertext.to_ptr,
+        ciphertext.bytesize,
+        nonce     .to_ptr,
+        shared_key.to_ptr
       ) or raise Sodium::CryptoError, 'failed to open the box'
     end.ldrop self.implementation[:ZEROBYTES]
   end
@@ -63,12 +63,12 @@ class Sodium::Box
 
     Sodium::Buffer.empty(message.bytesize) do |ciphertext|
       self.implementation.nacl(
-        ciphertext.to_str,
-        message.to_str,
-        message.to_str.bytesize,
-        nonce.to_str,
-        @public_key.to_str,
-        @secret_key.to_str
+        ciphertext .to_ptr,
+        message    .to_ptr,
+        message    .bytesize,
+        nonce      .to_ptr,
+        @public_key.to_ptr,
+        @secret_key.to_ptr
       ) or raise Sodium::CryptoError, 'failed to close the box'
     end.ldrop self.implementation[:BOXZEROBYTES]
   end
@@ -79,12 +79,12 @@ class Sodium::Box
 
     Sodium::Buffer.empty(ciphertext.bytesize) do |message|
       self.implementation.nacl_open(
-        message.to_str,
-        ciphertext.to_str,
-        ciphertext.to_str.bytesize,
-        nonce.to_str,
-        @public_key.to_str,
-        @secret_key.to_str
+        message    .to_ptr,
+        ciphertext .to_ptr,
+        ciphertext .bytesize,
+        nonce      .to_ptr,
+        @public_key.to_ptr,
+        @secret_key.to_ptr
       ) or raise Sodium::CryptoError, 'failed to open the box'
     end.ldrop self.implementation[:ZEROBYTES]
   end
@@ -92,9 +92,9 @@ class Sodium::Box
   def beforenm
     Sodium::Buffer.empty self.implementation[:BEFORENMBYTES] do |shared_key|
       self.implementation.nacl_beforenm(
-        shared_key.to_str,
-        @public_key.to_str,
-        @secret_key.to_str
+        shared_key .to_ptr,
+        @public_key.to_ptr,
+        @secret_key.to_ptr
       ) or raise Sodium::CryptoError, 'failed to create a shared key'
     end
   end

--- a/lib/sodium/ffi/lib_c.rb
+++ b/lib/sodium/ffi/lib_c.rb
@@ -5,5 +5,8 @@ module Sodium::FFI::LibC
 
   ffi_lib FFI::Library::LIBC
 
+  attach_function 'calloc', [:size_t, :size_t], :pointer
+  attach_function 'free',   [:pointer],         :void
+
   attach_function 'mlock', [:pointer, :size_t], :int
 end

--- a/lib/sodium/hash.rb
+++ b/lib/sodium/hash.rb
@@ -8,9 +8,9 @@ class Sodium::Hash
 
     Sodium::Buffer.empty self.implementation[:BYTES] do |digest|
       self.implementation.nacl(
-        digest.to_str,
-        message.to_str,
-        message.to_str.bytesize
+        digest .to_ptr,
+        message.to_ptr,
+        message.bytesize
       ) or raise Sodium::CryptoError, 'failed to generate a hash for the message'
     end
   end

--- a/lib/sodium/one_time_auth.rb
+++ b/lib/sodium/one_time_auth.rb
@@ -16,10 +16,10 @@ class Sodium::OneTimeAuth
 
     Sodium::Buffer.empty self.implementation[:BYTES] do |authenticator|
       self.implementation.nacl(
-        authenticator.to_str,
-        message.to_str,
-        message.to_str.bytesize,
-        @key.to_str
+        authenticator.to_ptr,
+        message      .to_ptr,
+        message      .bytesize,
+        @key         .to_ptr
       ) or raise Sodium::CryptoError, 'failed to generate an authenticator'
     end
   end
@@ -29,10 +29,10 @@ class Sodium::OneTimeAuth
     authenticator = self.class._authenticator(authenticator)
 
     self.implementation.nacl_verify(
-      authenticator.to_str,
-      message.to_str,
-      message.to_str.bytesize,
-      @key.to_str
+      authenticator.to_ptr,
+      message      .to_ptr,
+      message      .bytesize,
+      @key         .to_ptr
     )
   end
 

--- a/lib/sodium/random.rb
+++ b/lib/sodium/random.rb
@@ -4,7 +4,7 @@ module Sodium::Random
   def self.bytes(size)
     Sodium::Buffer.empty(size) do |buffer|
       Sodium::FFI::Random.randombytes_buf(
-        buffer.to_str,
+        buffer.to_ptr,
         buffer.bytesize
       )
     end

--- a/lib/sodium/secret_box.rb
+++ b/lib/sodium/secret_box.rb
@@ -21,11 +21,11 @@ class Sodium::SecretBox
 
     Sodium::Buffer.empty(message.bytesize) do |ciphertext|
       self.implementation.nacl(
-        ciphertext.to_str,
-        message.to_str,
-        message.to_str.bytesize,
-        nonce.to_str,
-        @key.to_str
+        ciphertext .to_ptr,
+        message    .to_ptr,
+        message    .bytesize,
+        nonce      .to_ptr,
+        @key       .to_ptr
       ) or raise Sodium::CryptoError, 'failed to close the secret box'
     end.ldrop self.implementation[:BOXZEROBYTES]
   end
@@ -36,11 +36,11 @@ class Sodium::SecretBox
 
     Sodium::Buffer.empty(ciphertext.bytesize) do |message|
       self.implementation.nacl_open(
-        message.to_str,
-        ciphertext.to_str,
-        ciphertext.to_str.bytesize,
-        nonce.to_str,
-        @key.to_str
+        message    .to_ptr,
+        ciphertext .to_ptr,
+        ciphertext .bytesize,
+        nonce      .to_ptr,
+        @key       .to_ptr
       ) or raise Sodium::CryptoError, 'failed to open the secret box'
     end.ldrop self.implementation[:ZEROBYTES]
   end

--- a/lib/sodium/sign.rb
+++ b/lib/sodium/sign.rb
@@ -8,8 +8,8 @@ class Sodium::Sign
     secret_key = Sodium::Buffer.empty self.implementation[:SECRETKEYBYTES]
 
     self.implementation.nacl_keypair(
-      public_key.to_str,
-      secret_key.to_str
+      public_key.to_ptr,
+      secret_key.to_ptr
     ) or raise Sodium::CryptoError, 'failed to generate a keypair'
 
     return secret_key, public_key
@@ -22,11 +22,11 @@ class Sodium::Sign
     mlen      = FFI::MemoryPointer.new(:ulong_long, 1, true)
 
     self.implementation.nacl_open(
-      message.to_str,
+      message   .to_ptr,
       mlen,
-      signature.to_str,
-      signature.to_str.bytesize,
-      key.to_str
+      signature .to_ptr,
+      signature .bytesize,
+      key       .to_ptr
     )
   end
 
@@ -40,18 +40,18 @@ class Sodium::Sign
     slen      = FFI::MemoryPointer.new(:ulong_long, 1, true)
 
     self.implementation.nacl(
-      signature.to_str,
+      signature .to_ptr,
       slen,
-      message.to_str,
-      message.to_str.bytesize,
-      @key.to_str
+      message   .to_ptr,
+      message   .bytesize,
+      @key      .to_ptr
     ) or raise Sodium::CryptoError, 'failed to generate signature'
 
     # signatures actually encode the message itself at the end, so we
     # slice off only the signature bytes
     signature.byteslice(
       0,
-      slen.read_ulong_long - message.to_str.bytesize
+      slen.read_ulong_long - message.bytesize
     )
   end
 

--- a/test/sodium/auth/hmacsha256_test.rb
+++ b/test/sodium/auth/hmacsha256_test.rb
@@ -36,11 +36,11 @@ describe Sodium::Auth::HMACSHA256 do
     self.klass.auth(
       self.key,
       self.plaintext
-    ).to_str.must_equal self.authenticator
+    ).to_s.must_equal self.authenticator
 
     self.subject.auth(
       self.plaintext
-    ).to_str.must_equal self.authenticator
+    ).to_s.must_equal self.authenticator
   end
 
   it 'must verify authenticators' do

--- a/test/sodium/auth/hmacsha512256_test.rb
+++ b/test/sodium/auth/hmacsha512256_test.rb
@@ -35,11 +35,11 @@ describe Sodium::Auth::HMACSHA512256 do
     self.klass.auth(
       self.key,
       self.plaintext
-    ).to_str.must_equal self.authenticator
+    ).to_s.must_equal self.authenticator
 
     self.subject.auth(
       self.plaintext
-    ).to_str.must_equal self.authenticator
+    ).to_s.must_equal self.authenticator
   end
 
   it 'must verify authenticators' do

--- a/test/sodium/auth_test.rb
+++ b/test/sodium/auth_test.rb
@@ -26,12 +26,12 @@ describe Sodium::Auth do
     sodium_mock_default(self.klass) do |klass, mock|
       mock.expect :[], 0, [:KEYBYTES]
 
-      klass.key.to_str.must_equal ''
+      klass.key.to_s.must_equal ''
     end
   end
 
   it 'must raise when instantiating with an invalid key' do
-    lambda { self.klass.new(self.key.to_str[0..-2]) }.
+    lambda { self.klass.new(self.key.to_s[0..-2]) }.
       must_raise Sodium::LengthError
   end
 

--- a/test/sodium/box/curve25519xsalsa20poly1305_test.rb
+++ b/test/sodium/box/curve25519xsalsa20poly1305_test.rb
@@ -47,18 +47,18 @@ describe Sodium::Box::Curve25519XSalsa20Poly1305 do
     self.subject.box(
       self.plaintext,
       self.nonce
-    ).to_str.must_equal self.ciphertext
+    ).to_s.must_equal self.ciphertext
   end
 
   it 'must open boxes' do
     self.subject.open(
       self.ciphertext,
       self.nonce
-    ).to_str.must_equal self.plaintext
+    ).to_s.must_equal self.plaintext
   end
 
   it 'must generate shared keys' do
-    self.subject.beforenm.to_str.must_equal self.shared_key
+    self.subject.beforenm.to_s.must_equal self.shared_key
   end
 
   it 'must generate closed boxes with shared keys' do
@@ -66,7 +66,7 @@ describe Sodium::Box::Curve25519XSalsa20Poly1305 do
       self.shared_key,
       self.plaintext,
       self.nonce
-    ).to_str.must_equal self.ciphertext
+    ).to_s.must_equal self.ciphertext
   end
 
   it 'must open boxes with shared keys' do
@@ -74,6 +74,6 @@ describe Sodium::Box::Curve25519XSalsa20Poly1305 do
       self.shared_key,
       self.ciphertext,
       self.nonce
-    ).to_str.must_equal self.plaintext
+    ).to_s.must_equal self.plaintext
   end
 end

--- a/test/sodium/box_test.rb
+++ b/test/sodium/box_test.rb
@@ -24,29 +24,29 @@ describe Sodium::Box do
 
   it 'must mint keypairs from the default implementation' do
     sodium_mock_default(self.klass) do |klass, mock|
-      mock.expect :nacl_keypair, true, [ '', '' ]
+      mock.expect :nacl_keypair, true, [ FFI::Pointer, FFI::Pointer ]
       mock.expect :[],           0,    [:PUBLICKEYBYTES]
       mock.expect :[],           0,    [:SECRETKEYBYTES]
 
       sk, pk = klass.keypair
 
-      sk.to_str.must_equal ''
-      pk.to_str.must_equal ''
+      sk.to_s.must_equal ''
+      pk.to_s.must_equal ''
     end
   end
 
   it 'must raise when instantiating with an invalid keypair' do
     secret_key, public_key = self.keypair
 
-    lambda { self.klass.new(secret_key.to_str[0..-2], public_key) }.
+    lambda { self.klass.new(secret_key.to_s[0..-2], public_key) }.
       must_raise Sodium::LengthError
 
-    lambda { self.klass.new(secret_key, public_key.to_str[0..-2]) }.
+    lambda { self.klass.new(secret_key, public_key.to_s[0..-2]) }.
       must_raise Sodium::LengthError
   end
 
   it 'must raise when receiving an invalid nonce' do
-    lambda { self.subject.box('message', self.subject.nonce.to_str[0..-2]) }.
+    lambda { self.subject.box('message', self.subject.nonce.to_s[0..-2]) }.
       must_raise Sodium::LengthError
   end
 

--- a/test/sodium/buffer_test.rb
+++ b/test/sodium/buffer_test.rb
@@ -3,29 +3,35 @@ require 'test_helper'
 describe Sodium::Buffer do
   subject { Sodium::Buffer }
 
+  def trigger_gc!
+    GC.start
+    1_000_000.times { Object.new }
+    GC.start
+  end
+
   it '::key must securely generate random keys of specified length' do
     Sodium::Random.stub(:bytes, lambda {|l| ' ' * l }) do
-      subject.key( 7).to_str.must_equal(' ' *  7)
-      subject.key( 8).to_str.must_equal(' ' *  8)
-      subject.key(16).to_str.must_equal(' ' * 16)
-      subject.key(32).to_str.must_equal(' ' * 32)
-      subject.key(64).to_str.must_equal(' ' * 64)
+      subject.key( 7).to_s.must_equal(' ' *  7)
+      subject.key( 8).to_s.must_equal(' ' *  8)
+      subject.key(16).to_s.must_equal(' ' * 16)
+      subject.key(32).to_s.must_equal(' ' * 32)
+      subject.key(64).to_s.must_equal(' ' * 64)
     end
   end
 
   it '::nonce must securely generate random nonces of specified length' do
     Sodium::Random.stub(:bytes, lambda {|l| ' ' * l }) do
-      subject.nonce( 7).to_str.must_equal(' ' *  7)
-      subject.nonce( 8).to_str.must_equal(' ' *  8)
-      subject.nonce(16).to_str.must_equal(' ' * 16)
-      subject.nonce(32).to_str.must_equal(' ' * 32)
-      subject.nonce(64).to_str.must_equal(' ' * 64)
+      subject.nonce( 7).to_s.must_equal(' ' *  7)
+      subject.nonce( 8).to_s.must_equal(' ' *  8)
+      subject.nonce(16).to_s.must_equal(' ' * 16)
+      subject.nonce(32).to_s.must_equal(' ' * 32)
+      subject.nonce(64).to_s.must_equal(' ' * 64)
     end
   end
 
   it '::empty must generate an empty buffer of specified length' do
-    subject.empty(32).to_str.must_equal("\0" * 32)
-    subject.empty(40).to_str.must_equal("\0" * 40)
+    subject.empty(32).to_s.must_equal("\0" * 32)
+    subject.empty(40).to_s.must_equal("\0" * 40)
   end
 
   it '::empty must yield to a block when given' do
@@ -38,43 +44,44 @@ describe Sodium::Buffer do
   end
 
   it '::ljust must pad zero bytes on the end' do
-    subject.ljust('xyz', 5).to_str.must_equal "xyz\0\0"
+    subject.ljust('xyz', 5).to_s.must_equal "xyz\0\0"
   end
 
   it '::ljust must not pad bytes when not needed' do
-    subject.ljust('xyz', 2).to_str.must_equal 'xyz'
+    subject.ljust('xyz', 2).to_s.must_equal 'xyz'
   end
 
   it '::rjust must pad zero bytes onto the front' do
-    subject.rjust('xyz', 5).to_str.must_equal "\0\0xyz"
+    subject.rjust('xyz', 5).to_s.must_equal "\0\0xyz"
   end
 
   it '::rjust must not pad bytes when not needed' do
-    subject.rjust('xyz', 2).to_str.must_equal 'xyz'
+    subject.rjust('xyz', 2).to_s.must_equal 'xyz'
   end
 
   it '::lpad must prepend the required number of bytes' do
-    subject.lpad('xyz', 0).to_str.must_equal 'xyz'
-    subject.lpad('xyz', 2).to_str.must_equal "\0\0xyz"
+    subject.lpad('xyz', 0).to_s.must_equal 'xyz'
+    subject.lpad('xyz', 2).to_s.must_equal "\0\0xyz"
   end
 
   it '::rpad must append the required number of bytes' do
-    subject.rpad('xyz', 0).to_str.must_equal 'xyz'
-    subject.rpad('xyz', 2).to_str.must_equal "xyz\0\0"
+    subject.rpad('xyz', 0).to_s.must_equal 'xyz'
+    subject.rpad('xyz', 2).to_s.must_equal "xyz\0\0"
   end
 
   it '::new must create a buffer containing the specified string' do
-    subject.new('xyz'     ).to_str.must_equal('xyz')
-    subject.new('xyz' * 50).to_str.must_equal('xyz' * 50)
+    subject.new('xyz'     ).to_s.must_equal('xyz')
+    subject.new('xyz' * 50).to_s.must_equal('xyz' * 50)
   end
 
   it '::new must do optional length checking' do
-    lambda { subject.new('xyz', 4).to_str }.
+    lambda { subject.new('xyz', 4).to_s }.
       must_raise Sodium::LengthError
   end
 
   it '#initialize must freeze its bytes' do
-    subject.new('s').to_str.must_be :frozen?
+    subject.new('s').to_ptr.must_be :frozen?
+    subject.new('s').to_s  .must_be :frozen?
   end
 
   it '#initialize must wipe the memory from the original string' do
@@ -87,27 +94,27 @@ describe Sodium::Buffer do
   it '#initialize must prevent the string from being paged to disk'
 
   it '#== must compare equality of two buffers' do
-    subject.new('xyz').==('xyz') .must_equal true
-    subject.new('xyz').==('xy')  .must_equal false
-    subject.new('xyz').==('xyzz').must_equal false
-    subject.new('xyz').==('abc') .must_equal false
+    subject.new('xyz').must_be :==, 'xyz'
+    subject.new('xyz').wont_be :==, 'xy'
+    subject.new('xyz').wont_be :==, 'xyzz'
+    subject.new('xyz').wont_be :==, 'abc'
   end
 
   it '#== must compare equality of two buffers in constant time'
 
   it '#+ must append two buffers' do
-    subject.new('xyz').+('abc').to_str.must_equal 'xyzabc'
+    subject.new('xyz').+('abc').to_s.must_equal 'xyzabc'
   end
 
   it '#^ must XOR two buffers' do
-    subject.new('xyz').^('xyz').to_str.must_equal "\0\0\0"
-    subject.new('xyz').^('xyz').to_str.must_equal "\0\0\0"
+    subject.new('xyz').^('xyz').to_s.must_equal "\0\0\0"
+    subject.new('xyz').^('xyz').to_s.must_equal "\0\0\0"
   end
 
   it '#[]= must allow replacement of byte ranges' do
-    subject.new('xyz').tap {|b| b[0, 3] = 'abc' }.to_str.must_equal 'abc'
-    subject.new('xyz').tap {|b| b[0, 2] = 'ab'  }.to_str.must_equal 'abz'
-    subject.new('xyz').tap {|b| b[2, 1] = 'c'   }.to_str.must_equal 'xyc'
+    subject.new('xyz').tap {|b| b[0, 3] = 'abc' }.to_s.must_equal 'abc'
+    subject.new('xyz').tap {|b| b[0, 2] = 'ab'  }.to_s.must_equal 'abz'
+    subject.new('xyz').tap {|b| b[2, 1] = 'c'   }.to_s.must_equal 'xyc'
   end
 
   it '#[]= must not allow resizing the buffer' do
@@ -117,61 +124,61 @@ describe Sodium::Buffer do
     lambda { subject.new('xyz')[2, 2] = 'ab' }.must_raise ArgumentError
   end
 
-  it '#[] must accept an indivdual byte offset to return' do
-    subject.new('xyz').tap do |buffer|
-      buffer[-4].to_str.must_equal ''
-      buffer[-3].to_str.must_equal 'x'
-      buffer[-2].to_str.must_equal 'y'
-      buffer[-1].to_str.must_equal 'z'
-      buffer[ 0].to_str.must_equal 'x'
-      buffer[ 1].to_str.must_equal 'y'
-      buffer[ 2].to_str.must_equal 'z'
-      buffer[ 3].to_str.must_equal ''
-    end
-  end
-
-  it '#[] must accept ranges of bytes to return' do
-    subject.new('xyz').tap do |buffer|
-      buffer[ 0.. 0].to_str.must_equal 'x'
-      buffer[ 0.. 1].to_str.must_equal 'xy'
-      buffer[ 0.. 2].to_str.must_equal 'xyz'
-      buffer[ 0.. 3].to_str.must_equal 'xyz'
-      buffer[ 1..-1].to_str.must_equal 'yz'
-      buffer[ 2..-2].to_str.must_equal ''
-      buffer[-3..-1].to_str.must_equal 'xyz'
-      buffer[-4.. 1].to_str.must_equal ''
-    end
-  end
-
   it '#[] must accept an offset and number of bytes to return' do
     subject.new('xyz').tap do |buffer|
-      buffer[ 0,  0].to_str.must_equal ''
-      buffer[ 0,  1].to_str.must_equal 'x'
-      buffer[ 0,  3].to_str.must_equal 'xyz'
-      buffer[ 2,  4].to_str.must_equal 'z'
-      buffer[ 2,  1].to_str.must_equal 'z'
-      buffer[-2,  1].to_str.must_equal 'y'
-      buffer[ 0, -1].to_str.must_equal ''
+      buffer[ 0,  0].to_s.must_equal ''
+      buffer[ 0,  1].to_s.must_equal 'x'
+      buffer[ 0,  3].to_s.must_equal 'xyz'
+      buffer[ 2,  1].to_s.must_equal 'z'
     end
   end
 
-  it '#[] must return its length' do
+  it '#bytesize must return its length' do
     subject.new('testing').bytesize.must_equal 7
   end
 
   it '#ldrop must drop bytes off the left' do
-    subject.new('xyz').ldrop(2).to_str.must_equal('z')
+    subject.new('xyz').ldrop(2).to_s.must_equal('z')
   end
 
   it '#rdrop must drop bytes off the right' do
-    subject.new('xyz').rdrop(2).to_str.must_equal('x')
+    subject.new('xyz').rdrop(2).to_s.must_equal('x')
   end
 
   it '#inspect must not reveal its instance variables' do
     subject.new('blah').inspect.wont_include 'blah'
   end
 
-  it '#to_str must return its internal bytes' do
-    subject.new('xyz').to_str.must_equal('xyz')
+  it '#to_s must return its internal bytes' do
+    subject.new('xyz').to_s.must_equal('xyz')
+  end
+
+  it '#to_ptr must return the live pointer to its data' do
+    subject.new('xyz').to_ptr.read_bytes(3).must_equal('xyz')
+  end
+
+
+  it 'must wipe its contents when garbage collected' do
+    address = lambda { Sodium::Buffer.new('xyz').to_ptr.address }
+    pointer = FFI::Pointer.new(address.call)
+
+    trigger_gc!
+
+    pointer.read_bytes(3).wont_equal('xyz')
+  end
+
+  it 'must free its contents when garbage collected' do
+    flag = MiniTest::Mock.new
+    free = lambda {|pointer| flag.called(pointer) }
+    flag.expect :called, nil, [ FFI::Pointer ]
+
+    Sodium::FFI::LibC.stub(:free, free) do
+      Sodium::Buffer.new('xyz')
+
+      trigger_gc!
+    end
+
+
+    flag.verify
   end
 end

--- a/test/sodium/hash/sha256_test.rb
+++ b/test/sodium/hash/sha256_test.rb
@@ -26,6 +26,6 @@ describe Sodium::Hash::SHA256 do
   it 'must generate hashes' do
     self.klass.hash(
       self.plaintext
-    ).to_str.must_equal self.hash
+    ).to_s.must_equal self.hash
   end
 end

--- a/test/sodium/hash/sha512_test.rb
+++ b/test/sodium/hash/sha512_test.rb
@@ -30,6 +30,6 @@ describe Sodium::Hash::SHA512 do
   it 'must generate hashes' do
     self.klass.hash(
       self.plaintext
-    ).to_str.must_equal self.hash
+    ).to_s.must_equal self.hash
   end
 end

--- a/test/sodium/hash_test.rb
+++ b/test/sodium/hash_test.rb
@@ -20,9 +20,10 @@ describe Sodium::Hash do
   it 'must hash from the default implementation' do
     sodium_mock_default(self.klass) do |klass, mock|
       mock.expect :[],   0,  [ :BYTES ]
-      mock.expect :nacl, '', [ String, self.plaintext, self.plaintext.bytesize ]
+      mock.expect :nacl, '',
+        [ FFI::Pointer, FFI::Pointer, self.plaintext.bytesize ]
 
-      klass.hash(self.plaintext).to_str.must_equal ''
+      klass.hash(self.plaintext).to_s.must_equal ''
     end
   end
 

--- a/test/sodium/one_time_auth/poly1305_test.rb
+++ b/test/sodium/one_time_auth/poly1305_test.rb
@@ -35,7 +35,7 @@ describe Sodium::OneTimeAuth::Poly1305 do
   it 'must generate authenticators' do
     self.subject.one_time_auth(
       self.plaintext
-    ).to_str.must_equal self.authenticator
+    ).to_s.must_equal self.authenticator
   end
 
   it 'must verify authenticators' do

--- a/test/sodium/one_time_auth_test.rb
+++ b/test/sodium/one_time_auth_test.rb
@@ -26,12 +26,12 @@ describe Sodium::OneTimeAuth do
     sodium_mock_default(self.klass) do |klass, mock|
       mock.expect :[], 0, [:KEYBYTES]
 
-      klass.key.to_str.must_equal ''
+      klass.key.to_s.must_equal ''
     end
   end
 
   it 'must raise when instantiating with an invalid key' do
-    lambda { self.klass.new(self.key.to_str[0..-2]) }.
+    lambda { self.klass.new(self.key.to_s[0..-2]) }.
       must_raise Sodium::LengthError
   end
 

--- a/test/sodium/secret_box/xsalsa20poly1305_test.rb
+++ b/test/sodium/secret_box/xsalsa20poly1305_test.rb
@@ -38,13 +38,13 @@ describe Sodium::SecretBox::XSalsa20Poly1305 do
     self.subject.secret_box(
       self.plaintext,
       self.nonce
-    ).to_str.must_equal self.ciphertext
+    ).to_s.must_equal self.ciphertext
   end
 
   it 'must open boxes' do
     self.subject.open(
       self.ciphertext,
       self.nonce
-    ).to_str.must_equal self.plaintext
+    ).to_s.must_equal self.plaintext
   end
 end

--- a/test/sodium/secret_box_test.rb
+++ b/test/sodium/secret_box_test.rb
@@ -26,17 +26,17 @@ describe Sodium::SecretBox do
     sodium_mock_default(self.klass) do |klass, mock|
       mock.expect :[], 0, [:KEYBYTES]
 
-      klass.key.to_str.must_equal ''
+      klass.key.to_s.must_equal ''
     end
   end
 
   it 'must raise when instantiating with an invalid key' do
-    lambda { self.klass.new(self.key.to_str[0..-2]) }.
+    lambda { self.klass.new(self.key.to_s[0..-2]) }.
       must_raise Sodium::LengthError
   end
 
   it 'must raise when receiving an invalid nonce' do
-    lambda { self.subject.secret_box('message', self.subject.nonce.to_str[0..-2]) }.
+    lambda { self.subject.secret_box('message', self.subject.nonce.to_s[0..-2]) }.
       must_raise Sodium::LengthError
   end
 

--- a/test/sodium/sign/ed25519_test.rb
+++ b/test/sodium/sign/ed25519_test.rb
@@ -41,7 +41,7 @@ describe Sodium::Sign::Ed25519 do
   end
 
   it 'must generate message signatures' do
-    self.subject.sign(self.plaintext).to_str.
+    self.subject.sign(self.plaintext).to_s.
       must_equal self.signature
   end
 

--- a/test/sodium/sign_test.rb
+++ b/test/sodium/sign_test.rb
@@ -24,21 +24,21 @@ describe Sodium::Sign do
 
   it 'must mint keys from the default implementation' do
     sodium_mock_default(self.klass) do |klass, mock|
-      mock.expect :nacl_keypair, true, ['', '']
+      mock.expect :nacl_keypair, true, [ FFI::Pointer, FFI::Pointer]
       mock.expect :[],           0,    [:PUBLICKEYBYTES]
       mock.expect :[],           0,    [:SECRETKEYBYTES]
 
       sk, pk = klass.keypair
 
-      sk.to_str.must_equal ''
-      pk.to_str.must_equal ''
+      sk.to_s.must_equal ''
+      pk.to_s.must_equal ''
     end
   end
 
   it 'must raise when instantiating with an invalid key' do
     secret_key = self.keypair.first
 
-    lambda { self.klass.new(secret_key.to_str[0..-2]) }.
+    lambda { self.klass.new(secret_key.to_s[0..-2]) }.
       must_raise Sodium::LengthError
   end
 


### PR DESCRIPTION
This avoids nastiness like copying garbage collectors from copying our memory
all over, forcing us to lose control of it. More importantly, we fix a nasty
bug related to garbage collection. If you retain a pointer to a
Sodium::Buffer's bytes but not the buffer itself, the buffer can be garbage
collected at any time (clearing your bytes).

The new implementation removes Sodium::Buffer#to_str and replaces it with
Sodium::Buffer#to_ptr and Sodium::Buffer#to_s. to_ptr gives you the actual
memory pointer to do with as you like. to_s gives you the actual String
contents, at which point guarantees are no longer made as to our ability to
clear the memory pointed to by the string. It is the caller's responsibility
never to call to_s on sensitive data unless absolutely necessary.
